### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ flask-blitzdb
 =============
 
 [![Build Status](https://travis-ci.org/puredistortion/flask-blitzdb.png?branch=master)](https://travis-ci.org/puredistortion/flask-blitzdb)
-[![PyPi version](https://pypip.in/v/flask-blitzdb/badge.png)](https://crate.io/packages/flask-blitzdb/)
-[![PyPi downloads](https://pypip.in/d/flask-blitzdb/badge.png)](https://crate.io/packages/flask-blitzdb/)
+[![PyPi version](https://img.shields.io/pypi/v/flask-blitzdb.svg
+[![PyPi downloads](https://img.shields.io/pypi/dm/flask-blitzdb.svg
 
 An extension to allow the integrated use of the [blitzdb](https://github.com/adewes/blitzdb) platform by [Andreas Dewes](http://www.andreas-dewes.de/en/)
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@ flask-blitzdb
 =============
 
 [![Build Status](https://travis-ci.org/puredistortion/flask-blitzdb.png?branch=master)](https://travis-ci.org/puredistortion/flask-blitzdb)
-[![PyPi version](https://img.shields.io/pypi/v/flask-blitzdb.svg
-[![PyPi downloads](https://img.shields.io/pypi/dm/flask-blitzdb.svg
+[![PyPi version](https://img.shields.io/pypi/v/flask-blitzdb.svg)](https://crate.io/packages/flask-blitzdb/)
 
 An extension to allow the integrated use of the [blitzdb](https://github.com/adewes/blitzdb) platform by [Andreas Dewes](http://www.andreas-dewes.de/en/)
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20flask-blitzdb))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `flask-blitzdb`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.